### PR TITLE
Add auth_profile service with JWT auth and profile management

### DIFF
--- a/alembic/versions/20240605_init_auth_profile.py
+++ b/alembic/versions/20240605_init_auth_profile.py
@@ -1,0 +1,36 @@
+"""Initial tables for auth_profile service"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240605_init_auth_profile'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('email', sa.String(length=255), nullable=False, unique=True),
+        sa.Column('password_hash', sa.String(length=255), nullable=False),
+        sa.Column('token_version', sa.Integer(), nullable=False, server_default='0'),
+    )
+    op.create_table(
+        'profiles',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False, unique=True),
+        sa.Column('first_name', sa.String(length=255)),
+        sa.Column('last_name', sa.String(length=255)),
+    )
+    op.create_table(
+        'consents',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False, unique=True),
+        sa.Column('marketing', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.Column('terms', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+    )
+
+def downgrade() -> None:
+    op.drop_table('consents')
+    op.drop_table('profiles')
+    op.drop_table('users')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,3 +66,16 @@ services:
       - ./infra/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     networks:
       - core-net
+  auth-profile:
+    build: ./services/auth_profile
+    ports:
+      - "8001:8000"
+    environment:
+      DATABASE_URL: postgresql+psycopg://cg:cg@postgres:5432/cityguide
+      JWT_SECRET: secret
+      KAFKA_BROKERS: redpanda:9092
+    depends_on:
+      - postgres
+      - redpanda
+    networks:
+      - core-net

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -11,3 +11,4 @@ scrape_configs:
           - prometheus:9090
           - grafana:3000
           - postgres:5432
+          - auth-profile:8000

--- a/services/auth_profile/Dockerfile
+++ b/services/auth_profile/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir fastapi uvicorn[standard] prometheus-client \
+       aiokafka opentelemetry-sdk opentelemetry-exporter-otlp \
+       opentelemetry-instrumentation-fastapi pydantic pydantic-settings \
+       sqlalchemy alembic psycopg[binary] pyjwt
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/auth_profile/README.md
+++ b/services/auth_profile/README.md
@@ -1,0 +1,19 @@
+# Template Service
+
+Minimal FastAPI service template with OpenTelemetry, Prometheus metrics and a Kafka consumer loop.
+
+## Running
+
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+### Endpoints
+
+* `/healthz` – liveness probe
+* `/readyz` – readiness probe
+* `/metrics` – Prometheus metrics
+
+### Kafka consumer
+
+Set the environment variables `KAFKA_BROKERS` and `KAFKA_TOPIC_IN` to start the Kafka consumer loop. On startup, a log message confirms the loop launch and messages are processed idempotently using an in-memory cache.

--- a/services/auth_profile/app/api.py
+++ b/services/auth_profile/app/api.py
@@ -1,0 +1,102 @@
+import json
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from aiokafka import AIOKafkaProducer
+
+from . import deps, models, schemas
+
+router = APIRouter()
+
+
+@router.post("/auth/register", status_code=201)
+def register(data: schemas.RegisterRequest, db: Session = Depends(deps.get_db)) -> dict:
+    if db.query(models.User).filter_by(email=data.email).first():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email already registered")
+    user = models.User(email=data.email, password_hash=deps.hash_password(data.password))
+    db.add(user)
+    db.flush()
+    db.add(models.Profile(user_id=user.id))
+    db.add(models.Consents(user_id=user.id))
+    db.commit()
+    return {"id": user.id}
+
+
+@router.post("/auth/login", response_model=schemas.TokenResponse)
+def login(data: schemas.LoginRequest, db: Session = Depends(deps.get_db)) -> schemas.TokenResponse:
+    user = db.query(models.User).filter_by(email=data.email).first()
+    if not user or not deps.verify_password(data.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    access, refresh = deps.create_tokens(user)
+    return schemas.TokenResponse(access_token=access, refresh_token=refresh)
+
+
+@router.post("/auth/refresh", response_model=schemas.TokenResponse)
+def refresh(data: schemas.RefreshRequest, db: Session = Depends(deps.get_db)) -> schemas.TokenResponse:
+    payload = deps.decode_token(data.refresh_token, "refresh")
+    user = db.get(models.User, payload["sub"])
+    if user is None or user.token_version != payload.get("token_version"):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    access, refresh_token = deps.create_tokens(user)
+    return schemas.TokenResponse(access_token=access, refresh_token=refresh_token)
+
+
+@router.post("/auth/logout_all")
+def logout_all(user: models.User = Depends(deps.get_current_user), db: Session = Depends(deps.get_db)) -> dict:
+    user.token_version += 1
+    db.commit()
+    return {"status": "ok"}
+
+
+@router.get("/profile", response_model=schemas.ProfileResponse)
+def get_profile(user: models.User = Depends(deps.get_current_user)) -> schemas.ProfileResponse:
+    return schemas.ProfileResponse(
+        email=user.email,
+        first_name=user.profile.first_name if user.profile else None,
+        last_name=user.profile.last_name if user.profile else None,
+    )
+
+
+async def _send_profile_updated(user: models.User) -> None:
+    settings = deps.get_settings()
+    if not settings.kafka_brokers:
+        return
+    producer = AIOKafkaProducer(bootstrap_servers=settings.kafka_brokers.split(","))
+    await producer.start()
+    try:
+        payload = json.dumps({"user_id": user.id}).encode()
+        await producer.send_and_wait("user.profile.updated", payload, key=str(user.id).encode())
+    finally:
+        await producer.stop()
+
+
+@router.patch("/profile", response_model=schemas.ProfileResponse)
+async def update_profile(
+    data: schemas.ProfileUpdate,
+    user: models.User = Depends(deps.get_current_user),
+    db: Session = Depends(deps.get_db),
+) -> schemas.ProfileResponse:
+    profile = user.profile or models.Profile(user_id=user.id)
+    for key, value in data.model_dump(exclude_unset=True).items():
+        setattr(profile, key, value)
+    db.add(profile)
+    db.commit()
+    await _send_profile_updated(user)
+    return schemas.ProfileResponse(
+        email=user.email,
+        first_name=profile.first_name,
+        last_name=profile.last_name,
+    )
+
+
+@router.put("/profile/consents", response_model=schemas.ConsentsResponse)
+def update_consents(
+    data: schemas.ConsentsUpdate,
+    user: models.User = Depends(deps.get_current_user),
+    db: Session = Depends(deps.get_db),
+) -> schemas.ConsentsResponse:
+    consents = user.consents or models.Consents(user_id=user.id)
+    for key, value in data.model_dump().items():
+        setattr(consents, key, value)
+    db.add(consents)
+    db.commit()
+    return schemas.ConsentsResponse.model_validate(consents)

--- a/services/auth_profile/app/deps.py
+++ b/services/auth_profile/app/deps.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta
+from functools import lru_cache
+import hashlib
+from typing import Generator
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic_settings import BaseSettings
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .models import User
+
+
+class Settings(BaseSettings):
+    database_url: str
+    jwt_secret: str = "secret"
+    jwt_algorithm: str = "HS256"
+    access_token_expire_minutes: int = 15
+    refresh_token_expire_days: int = 30
+    kafka_brokers: str | None = None
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()
+engine = create_engine(settings.database_url, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def get_db() -> Generator[Session, None, None]:
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+security = HTTPBearer()
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return hash_password(password) == hashed
+
+
+def create_tokens(user: User) -> tuple[str, str]:
+    now = datetime.utcnow()
+    access_payload = {
+        "sub": user.id,
+        "type": "access",
+        "token_version": user.token_version,
+        "exp": now + timedelta(minutes=settings.access_token_expire_minutes),
+    }
+    refresh_payload = {
+        "sub": user.id,
+        "type": "refresh",
+        "token_version": user.token_version,
+        "exp": now + timedelta(days=settings.refresh_token_expire_days),
+    }
+    access = jwt.encode(access_payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+    refresh = jwt.encode(refresh_payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+    return access, refresh
+
+
+def decode_token(token: str, token_type: str) -> dict:
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    except jwt.PyJWTError as exc:  # pragma: no cover
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+    if payload.get("type") != token_type:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+    return payload
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+    db: Session = Depends(get_db),
+) -> User:
+    payload = decode_token(credentials.credentials, "access")
+    user = db.get(User, payload["sub"])
+    if user is None or user.token_version != payload.get("token_version"):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return user

--- a/services/auth_profile/app/main.py
+++ b/services/auth_profile/app/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from .api import router
+
+app = FastAPI(title="auth_profile")
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/readyz")
+async def readyz() -> dict[str, str]:
+    return {"status": "ready"}
+
+
+app.include_router(router)

--- a/services/auth_profile/app/models.py
+++ b/services/auth_profile/app/models.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True, nullable=False)
+    password_hash = Column(String(255), nullable=False)
+    token_version = Column(Integer, nullable=False, default=0)
+
+    profile = relationship("Profile", back_populates="user", uselist=False)
+    consents = relationship("Consents", back_populates="user", uselist=False)
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, unique=True)
+    first_name = Column(String(255))
+    last_name = Column(String(255))
+
+    user = relationship("User", back_populates="profile")
+
+
+class Consents(Base):
+    __tablename__ = "consents"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, unique=True)
+    marketing = Column(Boolean, nullable=False, default=False)
+    terms = Column(Boolean, nullable=False, default=False)
+
+    user = relationship("User", back_populates="consents")

--- a/services/auth_profile/app/schemas.py
+++ b/services/auth_profile/app/schemas.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr
+
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class LoginRequest(RegisterRequest):
+    pass
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class ProfileUpdate(BaseModel):
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+
+
+class ProfileResponse(ProfileUpdate):
+    email: EmailStr
+
+    class Config:
+        from_attributes = True
+
+
+class ConsentsUpdate(BaseModel):
+    marketing: bool
+    terms: bool
+
+
+class ConsentsResponse(ConsentsUpdate):
+    class Config:
+        from_attributes = True

--- a/services/auth_profile/pyproject.toml
+++ b/services/auth_profile/pyproject.toml
@@ -1,0 +1,26 @@
+[tool.poetry]
+name = "auth_profile"
+version = "0.1.0"
+description = "Auth and profile service"
+authors = ["Example <example@example.com>"]
+packages = [{ include = "app" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.110.0"
+uvicorn = {version = "^0.30.0", extras = ["standard"]}
+prometheus-client = "^0.20.0"
+opentelemetry-sdk = "^1.24.0"
+opentelemetry-exporter-otlp = "^1.24.0"
+opentelemetry-instrumentation-fastapi = "^0.46b0"
+aiokafka = "^0.10.0"
+pydantic = "^2.7.0"
+pydantic-settings = "^2.1.0"
+sqlalchemy = "^2.0.0"
+alembic = "^1.13.0"
+psycopg = {version = "^3.1.0", extras = ["binary"]}
+pyjwt = "^2.8.0"
+
+[build-system]
+requires = ["poetry-core>=2.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add auth_profile microservice for registering, authenticating and managing user profiles and consents
- emit `user.profile.updated` Kafka events on profile update
- expose service via Docker Compose and Prometheus

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6ebb92d148327b5d92e5d74ab5809