### PR TITLE
Add route planner service with Kafka event

### DIFF
--- a/services/route_planner/Dockerfile
+++ b/services/route_planner/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir fastapi uvicorn[standard] prometheus-client \
+       aiokafka opentelemetry-sdk opentelemetry-exporter-otlp \
+       opentelemetry-instrumentation-fastapi pydantic pydantic-settings \
+       sqlalchemy alembic psycopg[binary]
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/route_planner/README.md
+++ b/services/route_planner/README.md
@@ -1,0 +1,8 @@
+# Route Planner Service
+
+Provides simple route preview and confirmation endpoints.
+
+## Endpoints
+
+- `POST /routes/preview` – preview a route between POIs
+- `POST /routes/confirm` – confirm a previewed route

--- a/services/route_planner/app/api.py
+++ b/services/route_planner/app/api.py
@@ -1,0 +1,139 @@
+import json
+import math
+from typing import Dict, Tuple
+from uuid import uuid4
+
+from aiokafka import AIOKafkaProducer
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from . import deps, models, schemas
+
+router = APIRouter()
+
+# Sample POI coordinates (lat, lon)
+POIS: Dict[int, tuple[float, float]] = {
+    1: (55.751244, 37.618423),  # Moscow
+    2: (59.9375, 30.308611),  # Saint Petersburg
+    3: (56.838926, 60.605703),  # Yekaterinburg
+    4: (55.030199, 82.92043),  # Novosibirsk
+}
+
+SPEED_M_PER_MIN = {
+    "car": 1000.0,  # ~60 km/h
+    "bike": 250.0,  # ~15 km/h
+    "walk": 83.0,  # ~5 km/h
+}
+
+_options: Dict[str, Tuple[schemas.RouteOption, str]] = {}
+
+
+def _haversine(p1: tuple[float, float], p2: tuple[float, float]) -> float:
+    lat1, lon1 = map(math.radians, p1)
+    lat2, lon2 = map(math.radians, p2)
+    dlat = lat2 - lat1
+    dlon = lon2 - lon1
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    )
+    c = 2 * math.asin(math.sqrt(a))
+    return 6371000 * c
+
+
+def _plan_route(poi_ids: list[int]) -> list[int]:
+    if not poi_ids:
+        return []
+    unvisited = poi_ids.copy()
+    current = unvisited.pop(0)
+    order = [current]
+    while unvisited:
+        next_poi = min(unvisited, key=lambda pid: _haversine(POIS[current], POIS[pid]))
+        unvisited.remove(next_poi)
+        order.append(next_poi)
+        current = next_poi
+    return order
+
+
+def _route_distance(order: list[int]) -> float:
+    if len(order) < 2:
+        return 0.0
+    return sum(_haversine(POIS[a], POIS[b]) for a, b in zip(order, order[1:]))
+
+
+@router.post("/routes/preview", response_model=schemas.PreviewResponse)
+async def preview_route(data: schemas.PreviewRequest) -> schemas.PreviewResponse:
+    try:
+        _ = [POIS[pid] for pid in data.poi_ids]
+    except KeyError as exc:  # pragma: no cover
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="POI not found"
+        ) from exc
+
+    order = _plan_route(data.poi_ids)
+    distance = _route_distance(order)
+    speed = SPEED_M_PER_MIN.get(data.mode, 1000.0)
+    eta = distance / speed if speed else 0.0
+    option_id = str(uuid4())
+    option = schemas.RouteOption(
+        option_id=option_id,
+        eta_min=eta,
+        distance_m=distance,
+        order=order,
+    )
+    _options[option_id] = (option, data.mode)
+    return schemas.PreviewResponse(options=[option])
+
+
+async def _send_route_confirmed(
+    route: models.Route, snapshot: models.RouteSnapshot
+) -> None:
+    settings = deps.get_settings()
+    if not settings.kafka_brokers:
+        return
+    producer = AIOKafkaProducer(bootstrap_servers=settings.kafka_brokers.split(","))
+    await producer.start()
+    try:
+        payload = {
+            "route_id": route.id,
+            "mode": route.mode,
+            "eta_min": route.eta_min,
+            "distance_m": route.distance_m,
+            "order": snapshot.order,
+        }
+        await producer.send_and_wait(
+            "route.confirmed", json.dumps(payload).encode(), key=str(route.id).encode()
+        )
+    finally:
+        await producer.stop()
+
+
+@router.post("/routes/confirm", response_model=schemas.ConfirmResponse)
+async def confirm_route(
+    data: schemas.ConfirmRequest,
+    db: Session = Depends(deps.get_db),
+) -> schemas.ConfirmResponse:
+    stored = _options.pop(data.option_id, None)
+    if stored is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Option not found"
+        )
+    option, mode = stored
+
+    route = models.Route(
+        mode=mode,
+        distance_m=int(option.distance_m),
+        eta_min=int(option.eta_min),
+    )
+    db.add(route)
+    db.flush()
+    snapshot = models.RouteSnapshot(
+        route_id=route.id,
+        order=option.order,
+        distance_m=int(option.distance_m),
+        eta_min=int(option.eta_min),
+    )
+    db.add(snapshot)
+    db.commit()
+    await _send_route_confirmed(route, snapshot)
+    return schemas.ConfirmResponse(route_id=route.id)

--- a/services/route_planner/app/deps.py
+++ b/services/route_planner/app/deps.py
@@ -1,0 +1,46 @@
+from functools import lru_cache
+from typing import Generator
+
+from pydantic_settings import BaseSettings
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+
+class Settings(BaseSettings):
+    database_url: str = "sqlite:///./route_planner.db"
+    kafka_brokers: str | None = None
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+_engine = None
+_SessionLocal: sessionmaker | None = None
+
+
+def get_sessionmaker() -> sessionmaker:
+    global _engine, _SessionLocal
+    if _SessionLocal is None:
+        settings = get_settings()
+        _engine = create_engine(settings.database_url, future=True)
+        _SessionLocal = sessionmaker(bind=_engine, autoflush=False, autocommit=False)
+    return _SessionLocal
+
+
+def get_db() -> Generator[Session, None, None]:
+    session_local = get_sessionmaker()
+    db = session_local()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def init_db() -> None:
+    from . import models
+
+    _ = get_sessionmaker()
+    assert _engine is not None
+    models.Base.metadata.create_all(bind=_engine)

--- a/services/route_planner/app/main.py
+++ b/services/route_planner/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+
+from . import deps
+from .api import router
+
+app = FastAPI(title="route_planner")
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    deps.init_db()
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+@app.get("/readyz")
+async def readyz() -> dict[str, str]:
+    return {"status": "ready"}
+
+app.include_router(router)

--- a/services/route_planner/app/models.py
+++ b/services/route_planner/app/models.py
@@ -1,0 +1,27 @@
+from sqlalchemy import JSON, Column, ForeignKey, Integer, String
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+
+class Route(Base):
+    __tablename__ = "routes"
+
+    id = Column(Integer, primary_key=True)
+    mode = Column(String(50), nullable=False)
+    distance_m = Column(Integer, nullable=False)
+    eta_min = Column(Integer, nullable=False)
+
+    snapshot = relationship("RouteSnapshot", back_populates="route", uselist=False)
+
+
+class RouteSnapshot(Base):
+    __tablename__ = "route_snapshots"
+
+    id = Column(Integer, primary_key=True)
+    route_id = Column(Integer, ForeignKey("routes.id"), nullable=False)
+    order = Column(JSON, nullable=False)
+    distance_m = Column(Integer, nullable=False)
+    eta_min = Column(Integer, nullable=False)
+
+    route = relationship("Route", back_populates="snapshot")

--- a/services/route_planner/app/schemas.py
+++ b/services/route_planner/app/schemas.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PreviewRequest(BaseModel):
+    poi_ids: list[int]
+    mode: str
+    duration_target_min: int
+
+
+class RouteOption(BaseModel):
+    option_id: str
+    eta_min: float
+    distance_m: float
+    order: list[int]
+
+
+class PreviewResponse(BaseModel):
+    options: list[RouteOption]
+
+
+class ConfirmRequest(BaseModel):
+    option_id: str = Field(alias="option_id")
+
+
+class ConfirmResponse(BaseModel):
+    route_id: int

--- a/services/route_planner/pyproject.toml
+++ b/services/route_planner/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.poetry]
+name = "route_planner"
+version = "0.1.0"
+description = "Route planner service"
+authors = ["Example <example@example.com>"]
+packages = [{ include = "app" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.110.0"
+uvicorn = {version = "^0.30.0", extras = ["standard"]}
+prometheus-client = "^0.20.0"
+opentelemetry-sdk = "^1.24.0"
+opentelemetry-exporter-otlp = "^1.24.0"
+opentelemetry-instrumentation-fastapi = "^0.46b0"
+aiokafka = "^0.10.0"
+pydantic = "^2.7.0"
+pydantic-settings = "^2.1.0"
+sqlalchemy = "^2.0.0"
+alembic = "^1.13.0"
+psycopg = {version = "^3.1.0", extras = ["binary"]}
+
+[build-system]
+requires = ["poetry-core>=2.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_route_planner.py
+++ b/tests/test_route_planner.py
@@ -1,0 +1,59 @@
+import json
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.route_planner.app import deps
+from services.route_planner.app.main import app
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    class TestSettings(deps.Settings):
+        database_url = "sqlite:///:memory:"
+        kafka_brokers = "kafka:9092"
+
+    monkeypatch.setattr(deps, "get_settings", lambda: TestSettings())
+    deps._engine = None  # type: ignore[attr-defined]
+    deps._SessionLocal = None  # type: ignore[attr-defined]
+    deps.init_db()
+
+    messages: list[dict[str, Any]] = []
+
+    from services.route_planner.app import api
+
+    class DummyProducer:
+        async def start(self) -> None:  # pragma: no cover - simple stub
+            pass
+
+        async def stop(self) -> None:  # pragma: no cover - simple stub
+            pass
+
+        async def send_and_wait(self, topic: str, value: bytes, key: bytes) -> None:
+            messages.append({"topic": topic, "value": value, "key": key})
+
+    monkeypatch.setattr(api, "AIOKafkaProducer", lambda *a, **k: DummyProducer())
+
+    client = TestClient(app)
+    client.kafka_messages = messages  # type: ignore[attr-defined]
+    return client
+
+
+def test_preview_and_confirm(client: TestClient) -> None:
+    resp = client.post(
+        "/routes/preview",
+        json={"poi_ids": [1, 2, 3], "mode": "car", "duration_target_min": 100},
+    )
+    assert resp.status_code == 200
+    option_id = resp.json()["options"][0]["option_id"]
+
+    resp2 = client.post("/routes/confirm", json={"option_id": option_id})
+    assert resp2.status_code == 200
+    route_id = resp2.json()["route_id"]
+
+    assert client.kafka_messages  # type: ignore[attr-defined]
+    msg = client.kafka_messages[0]  # type: ignore[index]
+    assert msg["topic"] == "route.confirmed"
+    payload = json.loads(msg["value"].decode())
+    assert payload["route_id"] == route_id


### PR DESCRIPTION
## Summary
- add new route_planner service with preview and confirmation endpoints
- store confirmed routes and snapshots, publishing `route.confirmed` Kafka events
- cover service with a test for preview and confirmation flow

## Testing
- `poetry run ruff check services/route_planner tests/test_route_planner.py`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi pydantic pydantic-settings sqlalchemy aiokafka uvicorn prometheus-client opentelemetry-sdk opentelemetry-exporter-otlp opentelemetry-instrumentation-fastapi alembic psycopg[binary]` *(fails: Could not find a version that satisfies the requirement fastapi)*


------
https://chatgpt.com/codex/tasks/task_e_68c6f3086d5c8327a66381571e4d4006