### PR TITLE
Add orchestrator service and workflow management

### DIFF
--- a/alembic/versions/20240615_add_orchestrator_workflows.py
+++ b/alembic/versions/20240615_add_orchestrator_workflows.py
@@ -1,0 +1,42 @@
+"""add orchestrator workflow tables"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20240615_orchestrator"
+down_revision = "20240605_init_auth_profile"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflows",
+        sa.Column("route_id", sa.String(), primary_key=True),
+        sa.Column("status", sa.String(), nullable=False),
+    )
+    op.create_table(
+        "workflow_steps",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "route_id", sa.String(), sa.ForeignKey("workflows.route_id"), nullable=False
+        ),
+        sa.Column("step", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("retries", sa.Integer(), nullable=False, default=0),
+    )
+    op.create_index(
+        "ix_workflow_steps_route_id", "workflow_steps", ["route_id"], unique=False
+    )
+    op.create_unique_constraint(
+        "uq_workflow_step", "workflow_steps", ["route_id", "step"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_workflow_step", "workflow_steps", type_="unique")
+    op.drop_index("ix_workflow_steps_route_id", table_name="workflow_steps")
+    op.drop_table("workflow_steps")
+    op.drop_table("workflows")

--- a/services/orchestrator/Dockerfile
+++ b/services/orchestrator/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir fastapi uvicorn[standard] prometheus-client \
+       aiokafka opentelemetry-sdk opentelemetry-exporter-otlp \
+       opentelemetry-instrumentation-fastapi pydantic pydantic-settings \
+       sqlalchemy alembic psycopg[binary]
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/orchestrator/README.md
+++ b/services/orchestrator/README.md
@@ -1,0 +1,4 @@
+# Orchestrator Service
+
+Handles workflow orchestration for generating stories, text-to-speech (TTS)
+requests and delivery prefetch planning.

--- a/services/orchestrator/app/api.py
+++ b/services/orchestrator/app/api.py
@@ -1,0 +1,53 @@
+"""API endpoints for workflow operations."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query
+from sqlalchemy import select
+
+from src.common.db import get_session
+
+from . import models, schemas
+
+router = APIRouter()
+
+
+@router.get("/workflows/{route_id}", response_model=schemas.WorkflowResponse)
+async def get_workflow(route_id: str) -> schemas.WorkflowResponse:
+    async with get_session() as session:
+        workflow = await session.get(models.Workflow, route_id)
+        if workflow is None:
+            raise HTTPException(status_code=404, detail="workflow not found")
+        result = await session.scalars(
+            select(models.WorkflowStep).where(models.WorkflowStep.route_id == route_id)
+        )
+        steps = [
+            schemas.WorkflowStepSchema(step=s.step, status=s.status, retries=s.retries)
+            for s in result
+        ]
+    return schemas.WorkflowResponse(
+        route_id=route_id,
+        status=workflow.status,
+        steps=steps,
+    )
+
+
+@router.post("/workflows/{route_id}/restart")
+async def restart_workflow(route_id: str, step: str = Query(...)) -> dict[str, str]:
+    if step != "tts_batch":
+        raise HTTPException(status_code=400, detail="unsupported step")
+    async with get_session() as session:
+        result = await session.scalars(
+            select(models.WorkflowStep).where(
+                models.WorkflowStep.route_id == route_id,
+                models.WorkflowStep.step.like("tts:%"),
+            )
+        )
+        steps = list(result)
+        if not steps:
+            raise HTTPException(status_code=404, detail="steps not found")
+        for s in steps:
+            s.status = "pending"
+            s.retries += 1
+        await session.commit()
+    return {"status": "ok"}

--- a/services/orchestrator/app/main.py
+++ b/services/orchestrator/app/main.py
@@ -1,0 +1,69 @@
+"""Entrypoint for orchestrator service."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Coroutine
+
+from fastapi import FastAPI
+
+from src.common.kafka import KafkaConsumer, KafkaProducer
+from src.common.settings import settings
+
+from . import api, workflow
+
+app = FastAPI()
+app.include_router(api.router)
+
+_producer: KafkaProducer | None = None
+
+
+async def _consume_route_confirmed(manager: workflow.WorkflowManager) -> None:
+    consumer = KafkaConsumer(
+        settings.kafka_brokers, "route.confirmed", group_id="orchestrator-route"
+    )
+    async with consumer:
+        async for msg in consumer:
+            await manager.handle_route_confirmed(msg.value)
+
+
+def _start_consumer(coro: Coroutine[Any, Any, None]) -> None:
+    loop = asyncio.get_event_loop()
+    loop.create_task(coro)
+
+
+async def _consume_story(manager: workflow.WorkflowManager) -> None:
+    consumer = KafkaConsumer(
+        settings.kafka_brokers, "story.generate", group_id="orchestrator-story"
+    )
+    async with consumer:
+        async for msg in consumer:
+            value = msg.value
+            if value.get("event") == "story.generate.completed":
+                await manager.handle_story_generate_completed(value)
+
+
+async def _consume_tts(manager: workflow.WorkflowManager) -> None:
+    consumer = KafkaConsumer(settings.kafka_brokers, "tts", group_id="orchestrator-tts")
+    async with consumer:
+        async for msg in consumer:
+            value = msg.value
+            if value.get("event") == "tts.completed":
+                await manager.handle_tts_completed(value)
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    global _producer
+    _producer = KafkaProducer(settings.kafka_brokers)
+    await _producer.start()
+    manager = workflow.WorkflowManager(_producer)
+    _start_consumer(_consume_route_confirmed(manager))
+    _start_consumer(_consume_story(manager))
+    _start_consumer(_consume_tts(manager))
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    if _producer:
+        await _producer.stop()

--- a/services/orchestrator/app/models.py
+++ b/services/orchestrator/app/models.py
@@ -1,0 +1,34 @@
+"""Database models for workflow orchestration."""
+
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+
+from src.common.db import Base
+
+
+class Workflow(Base):
+    __tablename__ = "workflows"
+
+    route_id = Column(String, primary_key=True)
+    status = Column(String, nullable=False)
+
+    steps = relationship(
+        "WorkflowStep", back_populates="workflow", cascade="all, delete-orphan"
+    )
+
+
+class WorkflowStep(Base):
+    __tablename__ = "workflow_steps"
+    __table_args__ = (UniqueConstraint("route_id", "step", name="uq_workflow_step"),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    route_id = Column(
+        String, ForeignKey("workflows.route_id"), index=True, nullable=False
+    )
+    step = Column(String, nullable=False)
+    status = Column(String, nullable=False)
+    retries = Column(Integer, nullable=False, default=0)
+
+    workflow = relationship("Workflow", back_populates="steps")

--- a/services/orchestrator/app/schemas.py
+++ b/services/orchestrator/app/schemas.py
@@ -1,0 +1,17 @@
+"""Pydantic schemas for API responses."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class WorkflowStepSchema(BaseModel):
+    step: str
+    status: str
+    retries: int
+
+
+class WorkflowResponse(BaseModel):
+    route_id: str
+    status: str
+    steps: list[WorkflowStepSchema]

--- a/services/orchestrator/app/workflow.py
+++ b/services/orchestrator/app/workflow.py
@@ -1,0 +1,94 @@
+"""Workflow orchestration logic."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import func, select
+
+from src.common.db import get_session
+from src.common.kafka import KafkaProducer
+
+from . import models
+
+
+class WorkflowManager:
+    """Handle workflow state transitions and Kafka messaging."""
+
+    def __init__(self, producer: KafkaProducer) -> None:
+        self.producer = producer
+
+    async def handle_route_confirmed(self, event: dict[str, Any]) -> None:
+        route_id = str(event["route_id"])
+        async with get_session() as session:
+            workflow = models.Workflow(route_id=route_id, status="story")
+            session.merge(workflow)
+            step = models.WorkflowStep(
+                route_id=route_id, step="story", status="pending", retries=0
+            )
+            session.merge(step)
+            await session.commit()
+        await self.producer.send(
+            "story.generate",
+            key=route_id,
+            value={"route_id": route_id, "lang": "ru"},
+        )
+
+    async def handle_story_generate_completed(self, event: dict[str, Any]) -> None:
+        route_id = str(event["route_id"])
+        stories = event.get("stories", [])
+        async with get_session() as session:
+            stmt = select(models.WorkflowStep).where(
+                models.WorkflowStep.route_id == route_id,
+                models.WorkflowStep.step == "story",
+            )
+            step = await session.scalar(stmt)
+            if step:
+                step.status = "completed"
+            for story in stories:
+                story_id = str(story["story_id"])
+                session.merge(
+                    models.WorkflowStep(
+                        route_id=route_id,
+                        step=f"tts:{story_id}",
+                        status="pending",
+                        retries=0,
+                    )
+                )
+            await session.commit()
+        for story in stories:
+            story_id = str(story["story_id"])
+            await self.producer.send(
+                "tts",
+                key=story_id,
+                value={"route_id": route_id, "story_id": story_id},
+            )
+
+    async def handle_tts_completed(self, event: dict[str, Any]) -> None:
+        route_id = str(event["route_id"])
+        story_id = str(event["story_id"])
+        async with get_session() as session:
+            stmt = select(models.WorkflowStep).where(
+                models.WorkflowStep.route_id == route_id,
+                models.WorkflowStep.step == f"tts:{story_id}",
+            )
+            step = await session.scalar(stmt)
+            if step:
+                step.status = "completed"
+            await session.commit()
+            remaining_stmt = (
+                select(func.count())
+                .select_from(models.WorkflowStep)
+                .where(
+                    models.WorkflowStep.route_id == route_id,
+                    models.WorkflowStep.step.like("tts:%"),
+                    models.WorkflowStep.status != "completed",
+                )
+            )
+            remaining = await session.scalar(remaining_stmt)
+        if not remaining:
+            await self.producer.send(
+                "delivery.prefetch",
+                key=route_id,
+                value={"route_id": route_id, "next_audio": []},
+            )

--- a/services/orchestrator/pyproject.toml
+++ b/services/orchestrator/pyproject.toml
@@ -1,0 +1,25 @@
+[tool.poetry]
+name = "orchestrator"
+version = "0.1.0"
+description = "Workflow orchestrator service"
+authors = ["Example <example@example.com>"]
+packages = [{ include = "app" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.110.0"
+uvicorn = {version = "^0.30.0", extras = ["standard"]}
+prometheus-client = "^0.20.0"
+opentelemetry-sdk = "^1.24.0"
+opentelemetry-exporter-otlp = "^1.24.0"
+opentelemetry-instrumentation-fastapi = "^0.46b0"
+aiokafka = "^0.10.0"
+pydantic = "^2.7.0"
+pydantic-settings = "^2.1.0"
+sqlalchemy = "^2.0.0"
+alembic = "^1.13.0"
+psycopg = {version = "^3.1.0", extras = ["binary"]}
+
+[build-system]
+requires = ["poetry-core>=2.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,65 @@
+import pytest
+from sqlalchemy import select
+
+from services.orchestrator.app import models, workflow
+from src.common import db
+from src.common.settings import Settings
+
+
+class DummyProducer:
+    def __init__(self) -> None:
+        self.messages: list[dict[str, object]] = []
+
+    async def start(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+    async def stop(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+    async def send(self, topic: str, key: str, value: dict[str, object]) -> None:
+        self.messages.append({"topic": topic, "key": key, "value": value})
+
+
+@pytest.mark.anyio
+async def test_story_and_tts_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    class TestSettings(Settings):
+        kafka_brokers = "kafka:9092"
+        postgres_dsn = "sqlite+aiosqlite:///:memory:"
+
+    from src.common import settings as common_settings
+
+    monkeypatch.setattr(common_settings, "settings", TestSettings())
+    monkeypatch.setattr(db, "_engine", None)
+    monkeypatch.setattr(db, "_sessionmaker", None)
+
+    engine = db.get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(db.Base.metadata.create_all)
+
+    producer = DummyProducer()
+    manager = workflow.WorkflowManager(producer)
+
+    await manager.handle_route_confirmed({"route_id": "r1"})
+    assert producer.messages
+    msg = producer.messages[0]
+    assert msg["topic"] == "story.generate"
+    assert msg["value"]["route_id"] == "r1"
+
+    producer.messages.clear()
+
+    await manager.handle_story_generate_completed(
+        {"route_id": "r1", "stories": [{"story_id": "s1"}, {"story_id": "s2"}]}
+    )
+    assert len(producer.messages) == 2
+    topics = {m["topic"] for m in producer.messages}
+    assert topics == {"tts"}
+    story_ids = {m["value"]["story_id"] for m in producer.messages}
+    assert story_ids == {"s1", "s2"}
+
+    async with db.get_session() as session:
+        steps = (
+            await session.scalars(
+                select(models.WorkflowStep).where(models.WorkflowStep.route_id == "r1")
+            )
+        ).all()
+    assert any(s.step == "story" and s.status == "completed" for s in steps)


### PR DESCRIPTION
## Summary
- implement orchestrator service with Kafka consumers to drive story/TTS workflow
- add workflow state tables and Alembic migration
- expose workflow inspection and restart endpoints

## Testing
- `ruff check services/orchestrator tests/test_orchestrator.py alembic/versions/20240615_add_orchestrator_workflows.py`
- `pytest -q` *(fails: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c6ff160ca08327a27bbb5f057c7162