### PR TITLE
Add paywall billing service with IAP stubs

### DIFF
--- a/services/paywall_billing/Dockerfile
+++ b/services/paywall_billing/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir fastapi uvicorn[standard]
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/paywall_billing/README.md
+++ b/services/paywall_billing/README.md
@@ -1,0 +1,9 @@
+# Paywall Billing Service
+
+Stub service providing simple paywall and in-app purchase validation.
+
+## Endpoints
+
+- `GET /paywall/check?action=` – returns `{show: bool}` based on daily free quota.
+- `POST /iap/validate` – accepts `{platform, receipt}` and activates subscription.
+- `GET /iap/status` – returns current subscription `{status, expire_at}`.

--- a/services/paywall_billing/app/__init__.py
+++ b/services/paywall_billing/app/__init__.py
@@ -1,0 +1,1 @@
+# Paywall billing service package

--- a/services/paywall_billing/app/api.py
+++ b/services/paywall_billing/app/api.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter
+
+from . import schemas
+
+router = APIRouter()
+
+_FREE_PER_DAY = 1
+_usage_day = ""
+_usage_count = 0
+
+_subscription: dict[str, datetime | str | None] = {
+    "status": "inactive",
+    "expire_at": None,
+}
+
+
+def _today() -> str:
+    return datetime.utcnow().date().isoformat()
+
+
+@router.get(
+    "/paywall/check",
+    response_model=schemas.PaywallCheckResponse,
+    response_model_exclude_none=True,
+)
+def paywall_check(action: str) -> schemas.PaywallCheckResponse:
+    global _usage_day, _usage_count
+    today = _today()
+    if _usage_day != today:
+        _usage_day = today
+        _usage_count = 0
+    show = _usage_count >= _FREE_PER_DAY
+    if not show:
+        _usage_count += 1
+    return schemas.PaywallCheckResponse(show=show)
+
+
+@router.post(
+    "/iap/validate",
+    response_model=schemas.IAPStatusResponse,
+    response_model_exclude_none=True,
+)
+def iap_validate(data: schemas.IAPValidateRequest) -> schemas.IAPStatusResponse:
+    expire_at = datetime.utcnow() + timedelta(days=30)
+    _subscription["status"] = "active"
+    _subscription["expire_at"] = expire_at
+    return schemas.IAPStatusResponse(status="active", expire_at=expire_at)
+
+
+@router.get(
+    "/iap/status",
+    response_model=schemas.IAPStatusResponse,
+    response_model_exclude_none=True,
+)
+def iap_status() -> schemas.IAPStatusResponse:
+    status = _subscription["status"]
+    expire_at = _subscription["expire_at"]
+    if (
+        status == "active"
+        and isinstance(expire_at, datetime)
+        and expire_at < datetime.utcnow()
+    ):
+        status = "expired"
+        _subscription["status"] = status
+    return schemas.IAPStatusResponse(
+        status=status,
+        expire_at=expire_at if isinstance(expire_at, datetime) else None,
+    )

--- a/services/paywall_billing/app/main.py
+++ b/services/paywall_billing/app/main.py
@@ -1,0 +1,18 @@
+from fastapi import FastAPI
+
+from .api import router
+
+app = FastAPI(title="paywall_billing")
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/readyz")
+def readyz() -> dict[str, str]:
+    return {"status": "ready"}
+
+
+app.include_router(router)

--- a/services/paywall_billing/app/schemas.py
+++ b/services/paywall_billing/app/schemas.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class PaywallCheckResponse(BaseModel):
+    show: bool
+    reason: str | None = None
+    sku: str | None = None
+
+
+class IAPValidateRequest(BaseModel):
+    platform: str
+    receipt: str
+
+
+class IAPStatusResponse(BaseModel):
+    status: str
+    expire_at: datetime | None = None

--- a/services/paywall_billing/poetry.lock
+++ b/services/paywall_billing/poetry.lock
@@ -1,0 +1,1 @@
+# Dependencies are managed at repository root; lock file intentionally minimal.

--- a/services/paywall_billing/pyproject.toml
+++ b/services/paywall_billing/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "paywall_billing"
+version = "0.1.0"
+description = "Paywall billing service"
+authors = ["Example <example@example.com>"]
+packages = [{ include = "app" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.110.0"
+uvicorn = {version = "^0.30.0", extras = ["standard"]}
+
+[build-system]
+requires = ["poetry-core>=2.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_paywall_billing.py
+++ b/tests/test_paywall_billing.py
@@ -1,0 +1,46 @@
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.paywall_billing.app.main import app
+
+
+@pytest.fixture(autouse=True)
+def reset_state() -> None:
+    api = importlib.import_module("services.paywall_billing.app.api")
+    api._usage_day = ""  # type: ignore[attr-defined]
+    api._usage_count = 0  # type: ignore[attr-defined]
+    api._subscription = {"status": "inactive", "expire_at": None}  # type: ignore[attr-defined]
+
+
+def test_paywall_check_limit() -> None:
+    client = TestClient(app)
+    resp1 = client.get("/paywall/check", params={"action": "route"})
+    assert resp1.status_code == 200
+    assert resp1.json() == {"show": False}
+
+    resp2 = client.get("/paywall/check", params={"action": "route"})
+    assert resp2.status_code == 200
+    assert resp2.json()["show"] is True
+
+
+def test_iap_validate_and_status() -> None:
+    client = TestClient(app)
+    resp = client.get("/iap/status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "inactive"
+
+    resp_val = client.post(
+        "/iap/validate", json={"platform": "ios", "receipt": "dummy"}
+    )
+    assert resp_val.status_code == 200
+    data = resp_val.json()
+    assert data["status"] == "active"
+    assert data["expire_at"]
+
+    resp_status = client.get("/iap/status")
+    assert resp_status.status_code == 200
+    data2 = resp_status.json()
+    assert data2["status"] == "active"
+    assert data2["expire_at"] == data["expire_at"]


### PR DESCRIPTION
## Summary
- add paywall_billing service providing paywall check and IAP endpoints
- stub validation and subscription status handling
- cover basic paywall and IAP flows with tests

## Testing
- `poetry run black services/paywall_billing tests/test_paywall_billing.py`
- `poetry run ruff check services/paywall_billing tests/test_paywall_billing.py`
- `make lint` *(fails: import block unsorted, long lines)*
- `make typecheck` *(fails: source file found twice under different module names)*
- `make tests` *(fails: ModuleNotFoundError: No module named 'services')*
- `PYTHONPATH=. poetry run pytest tests/test_paywall_billing.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7bafd9e20832799265f5ae6ad8fb8