### PR TITLE
feat(paywall): add reason and sku to paywall check

### DIFF
--- a/services/paywall_billing/README.md
+++ b/services/paywall_billing/README.md
@@ -4,6 +4,7 @@ Stub service providing simple paywall and in-app purchase validation.
 
 ## Endpoints
 
-- `GET /paywall/check?action=` – returns `{show: bool}` based on daily free quota.
+- `GET /paywall/check?action=` – returns `{show: bool, reason?, sku?}` based on
+  daily free quota.
 - `POST /iap/validate` – accepts `{platform, receipt}` and activates subscription.
 - `GET /iap/status` – returns current subscription `{status, expire_at}`.

--- a/services/paywall_billing/app/api.py
+++ b/services/paywall_billing/app/api.py
@@ -32,9 +32,12 @@ def paywall_check(action: str) -> schemas.PaywallCheckResponse:
         _usage_day = today
         _usage_count = 0
     show = _usage_count >= _FREE_PER_DAY
-    if not show:
-        _usage_count += 1
-    return schemas.PaywallCheckResponse(show=show)
+    if show:
+        return schemas.PaywallCheckResponse(
+            show=True, reason="daily_limit", sku="premium"
+        )
+    _usage_count += 1
+    return schemas.PaywallCheckResponse(show=False)
 
 
 @router.post(


### PR DESCRIPTION
## Summary
- include reason and sku when paywall limit exceeded
- document extended response in README

## Testing
- `PYTHONPATH=. pytest tests/test_paywall_billing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7bfd8f030832786d9988815817a89