### PR TITLE
feat: add OpenTelemetry tracing

### DIFF
--- a/services/delivery_prefetch/app/main.py
+++ b/services/delivery_prefetch/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from src.common.metrics import KAFKA_CONSUMER_LAG, JOB_DURATION, setup_metrics
+from src.common.telemetry import setup_otel
 
 from . import deps
 from .api import router
@@ -9,6 +10,7 @@ from .kafka_loop import start_kafka_consumer
 
 app = FastAPI(title="delivery_prefetch")
 setup_metrics(app, "delivery_prefetch")
+setup_otel(app, "delivery_prefetch")
 
 
 @app.on_event("startup")

--- a/services/orchestrator/app/main.py
+++ b/services/orchestrator/app/main.py
@@ -9,12 +9,14 @@ from fastapi import FastAPI
 
 from src.common.kafka import KafkaConsumer, KafkaProducer
 from src.common.metrics import KAFKA_CONSUMER_LAG, JOB_DURATION, setup_metrics
+from src.common.telemetry import setup_otel
 from src.common.settings import settings
 
 from . import api, workflow
 
 app = FastAPI()
 setup_metrics(app, "orchestrator")
+setup_otel(app, "orchestrator")
 app.include_router(api.router)
 
 _producer: KafkaProducer | None = None

--- a/services/route_planner/app/deps.py
+++ b/services/route_planner/app/deps.py
@@ -4,9 +4,10 @@ from typing import Generator
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+from src.common.settings import SettingsMeta
 
 
-class Settings(BaseSettings):
+class Settings(BaseSettings, metaclass=SettingsMeta):
     database_url: str = "sqlite:///./route_planner.db"
     kafka_brokers: str | None = None
 

--- a/services/route_planner/app/main.py
+++ b/services/route_planner/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from src.common.metrics import KAFKA_CONSUMER_LAG, JOB_DURATION, setup_metrics
+from src.common.telemetry import setup_otel
 
 from . import deps
 from .api import router
@@ -8,6 +9,7 @@ from .api import router
 
 app = FastAPI(title="route_planner")
 setup_metrics(app, "route_planner")
+setup_otel(app, "route_planner")
 
 
 @app.on_event("startup")

--- a/services/story_service/app/deps.py
+++ b/services/story_service/app/deps.py
@@ -4,9 +4,10 @@ from typing import Generator
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+from src.common.settings import SettingsMeta
 
 
-class Settings(BaseSettings):
+class Settings(BaseSettings, metaclass=SettingsMeta):
     database_url: str = "sqlite:///./story_service.db"
     kafka_brokers: str | None = None
     forbidden_words: str = "forbidden,bad"

--- a/services/story_service/app/main.py
+++ b/services/story_service/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from src.common.metrics import KAFKA_CONSUMER_LAG, JOB_DURATION, setup_metrics
+from src.common.telemetry import setup_otel
 
 from . import deps
 from .api import router
@@ -8,6 +9,7 @@ from .api import router
 
 app = FastAPI(title="story_service")
 setup_metrics(app, "story_service")
+setup_otel(app, "story_service")
 
 
 @app.on_event("startup")

--- a/services/tts_service/app/deps.py
+++ b/services/tts_service/app/deps.py
@@ -5,9 +5,10 @@ from typing import Generator
 from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
+from src.common.settings import SettingsMeta
 
 
-class Settings(BaseSettings):
+class Settings(BaseSettings, metaclass=SettingsMeta):
     database_url: str = "sqlite:///./tts_service.db"
     kafka_brokers: str | None = None
     audio_dir: str = "data/audio"

--- a/services/tts_service/app/main.py
+++ b/services/tts_service/app/main.py
@@ -1,13 +1,8 @@
 import logging
 from fastapi import FastAPI
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from src.common.metrics import KAFKA_CONSUMER_LAG, JOB_DURATION, setup_metrics
+from src.common.telemetry import setup_otel
 
 from .api import router as api_router
 from .deps import ensure_audio_dir, get_settings, init_db
@@ -16,23 +11,13 @@ from .kafka_loop import start_kafka_consumer
 logger = logging.getLogger(__name__)
 
 
-def setup_otel(app: FastAPI) -> None:
-    """Configure basic OpenTelemetry for the service."""
-    resource = Resource(attributes={SERVICE_NAME: "tts_service"})
-    provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(OTLPSpanExporter())
-    provider.add_span_processor(processor)
-    trace.set_tracer_provider(provider)
-    FastAPIInstrumentor.instrument_app(app)
-
-
 app = FastAPI(title="tts_service")
 setup_metrics(app, "tts_service")
+setup_otel(app, "tts_service")
 
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    setup_otel(app)
     settings = get_settings()
     init_db()
     ensure_audio_dir()

--- a/src/common/logging.py
+++ b/src/common/logging.py
@@ -6,6 +6,21 @@ import logging
 from typing import Any
 
 import structlog
+from opentelemetry.trace import get_current_span
+
+
+def _add_trace_id(
+    _logger: structlog.typing.WrappedLogger,
+    _name: str,
+    event_dict: dict[str, Any],
+) -> dict[str, Any]:
+    """Inject ``trace_id`` from the current span into log records."""
+
+    span = get_current_span()
+    ctx = span.get_span_context()
+    if ctx.trace_id:
+        event_dict["trace_id"] = f"{ctx.trace_id:032x}"
+    return event_dict
 
 
 def setup_logging(level: int = logging.INFO) -> None:
@@ -18,6 +33,7 @@ def setup_logging(level: int = logging.INFO) -> None:
             structlog.contextvars.merge_contextvars,
             timestamper,
             structlog.processors.add_log_level,
+            _add_trace_id,
             structlog.processors.DictRenderer(),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(level),


### PR DESCRIPTION
## Summary
- initialize OpenTelemetry in services and send trace/span data
- wrap Kafka message production in spans
- add trace IDs to structured logs

## Testing
- `KAFKA_BROKERS=localhost POSTGRES_DSN=sqlite:// PYTHONPATH=. pytest` *(fails: Missing trio module and database errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ca8cb5ec8327b8ec217e26ceeb83