### PR TITLE
Add CI workflow with linting, type checks, tests and Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'poetry'
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install --no-interaction --no-root
+      - name: Lint
+        run: poetry run ruff check .
+      - name: Typecheck
+        run: poetry run mypy .
+      - name: Tests
+        run: poetry run pytest -q
+
+  docker:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - service: auth_profile
+            path: services/auth_profile
+          - service: delivery_prefetch
+            path: services/delivery_prefetch
+          - service: orchestrator
+            path: services/orchestrator
+          - service: paywall_billing
+            path: services/paywall_billing
+          - service: route_planner
+            path: services/route_planner
+          - service: story_service
+            path: services/story_service
+          - service: tts_service
+            path: services/tts_service
+          - service: trip_runtime
+            path: services/trip_runtime
+          - service: template_service
+            path: template_service
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Build and push image
+        env:
+          IMAGE: ghcr.io/${{ secrets.GHCR_USERNAME }}/${{ matrix.service }}
+        run: |
+          docker build -t $IMAGE:${{ github.sha }} ${{ matrix.path }}
+          docker push $IMAGE:${{ github.sha }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using Python 3.11 and Poetry cache
- run linting (ruff), typechecking (mypy) and tests (pytest)
- build and push docker images for each service to GHCR

## Testing
- `poetry run ruff check .`
- `poetry run mypy .`
- `poetry run pytest -q`
- `curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d2bb4d208327982a9e958bc87948