### PR TITLE
Add smoke test scripts

### DIFF
--- a/scripts/smoke.http
+++ b/scripts/smoke.http
@@ -1,0 +1,92 @@
+@auth = http://localhost:8001
+@routes = http://localhost:8002
+@prefetch = http://localhost:8006
+@trip = http://localhost:8007
+@email = user{{timestamp}}@example.com
+
+###
+# Register
+POST {{auth}}/auth/register
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "pass"
+}
+
+###
+# Login
+POST {{auth}}/auth/login
+Content-Type: application/json
+
+{
+  "email": "{{email}}",
+  "password": "pass"
+}
+
+> {% client.global.set("token", response.body.access_token) %}
+
+###
+# Preview route
+POST {{routes}}/routes/preview
+Content-Type: application/json
+
+{
+  "poi_ids": [1,2,3,4],
+  "mode": "car",
+  "duration_target_min": 60
+}
+
+> {% client.global.set("optionId", response.body.options[0].option_id) %}
+
+###
+# Confirm route
+POST {{routes}}/routes/confirm
+Content-Type: application/json
+
+{
+  "option_id": "{{optionId}}"
+}
+
+> {% client.global.set("routeId", response.body.route_id) %}
+
+###
+# Wait for events
+@sleep(1000)
+
+###
+# Prefetch
+GET {{prefetch}}/delivery/prefetch?route_id={{routeId}}&next=1
+
+###
+# Start trip
+POST {{trip}}/trip/start
+Content-Type: application/json
+
+{
+  "route_id": {{routeId}}
+}
+
+> {% client.global.set("sessionId", response.body.session_id) %}
+
+###
+# Ping trip
+POST {{trip}}/trip/ping
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}",
+  "points": [
+    {"lat": 55.751244, "lon": 37.618423}
+  ]
+}
+
+###
+# Finish trip
+POST {{trip}}/trip/finish
+Content-Type: application/json
+
+{
+  "session_id": "{{sessionId}}"
+}
+

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUTH=http://localhost:8001
+ROUTES=http://localhost:8002
+PREFETCH=http://localhost:8006
+TRIP=http://localhost:8007
+
+EMAIL="user$RANDOM@example.com"
+PASSWORD="pass"
+
+# Register user
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$AUTH/auth/register" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}"
+
+# Login and extract token
+ACCESS=$(curl -s -X POST "$AUTH/auth/login" -H "Content-Type: application/json" \
+  -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}" | jq -r .access_token)
+
+echo "token: ${ACCESS:0:8}..."
+
+# Preview route and capture option id
+OPTION=$(curl -s -X POST "$ROUTES/routes/preview" -H "Content-Type: application/json" \
+  -d '{"poi_ids":[1,2,3,4],"mode":"car","duration_target_min":60}' | jq -r '.options[0].option_id')
+
+# Confirm route and capture route id
+ROUTE=$(curl -s -X POST "$ROUTES/routes/confirm" -H "Content-Type: application/json" \
+  -d "{\"option_id\":\"$OPTION\"}" | jq -r .route_id)
+
+echo "route: $ROUTE"
+
+sleep 1
+
+# Prefetch
+curl -s -o /dev/null -w "%{http_code}\n" "$PREFETCH/delivery/prefetch?route_id=$ROUTE&next=1"
+
+# Start trip and capture session id
+SESSION=$(curl -s -X POST "$TRIP/trip/start" -H "Content-Type: application/json" \
+  -d "{\"route_id\":$ROUTE}" | jq -r .session_id)
+
+echo "session: $SESSION"
+
+# Ping trip
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$TRIP/trip/ping" -H "Content-Type: application/json" \
+  -d "{\"session_id\":\"$SESSION\",\"points\":[{\"lat\":55.751244,\"lon\":37.618423}]}"
+
+# Finish trip
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$TRIP/trip/finish" -H "Content-Type: application/json" \
+  -d "{\"session_id\":\"$SESSION\"}"
+


### PR DESCRIPTION
## Summary
- add VS Code REST Client scenario for registration, route preview/confirm, and trip
- add bash smoke test script using curl

## Testing
- `KAFKA_BROKERS=1 POSTGRES_DSN=1 OTEL_METRICS_EXPORTER=none OTEL_TRACES_EXPORTER=none PYTHONPATH=. pytest tests/test_route_planner.py::test_preview_and_confirm -q` *(fails: HTTPConnectionPool host='localhost', port=4318 connection refused)*
- `scripts/smoke.sh` *(fails: curl returns 000 because services are unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e3ae34dc83279793ae42ff6f3e91